### PR TITLE
Modify Github Action of Scala

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -17,19 +17,23 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup
-        uses: olafurpg/setup-scala@v13
+        uses: actions/setup-java@v2
         with:
-          java-version: "adopt@1.8"
+          distribution: adopt
+          java-version: 8
 
       - name: Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6
 
       - name: Build and Test
         run: |
           sbt -v +test
+
+      - name: Cleanup before cache
+        shell: bash
+        run: |
           rm -rf "$HOME/.ivy2/local" || true
           find $HOME/Library/Caches/Coursier/v1        -name "ivydata-*.properties" -delete || true
           find $HOME/.ivy2/cache                       -name "ivydata-*.properties" -delete || true
           find $HOME/.cache/coursier/v1                -name "ivydata-*.properties" -delete || true
           find $HOME/.sbt                              -name "*.lock"               -delete || true
-

--- a/scala/src/test/scala/example/CalcSpec.scala
+++ b/scala/src/test/scala/example/CalcSpec.scala
@@ -17,8 +17,8 @@ class CalcSpec extends AnyWordSpec with Matchers {
       val actual   = calc.add(x, y)
       val expected = 3
 
-      fail("intentional failure")
-      // actual mustBe expected
+      // fail("intentional failure")
+      actual mustBe expected
     }
   }
 }

--- a/scala/src/test/scala/example/CalcSpec.scala
+++ b/scala/src/test/scala/example/CalcSpec.scala
@@ -17,8 +17,8 @@ class CalcSpec extends AnyWordSpec with Matchers {
       val actual   = calc.add(x, y)
       val expected = 3
 
-      // fail("intentional failure")
-      actual mustBe expected
+      fail("intentional failure")
+      // actual mustBe expected
     }
   }
 }


### PR DESCRIPTION
- Caching doesn't work now. Let it work.
- [sbt document](https://www.scala-sbt.org/1.x/docs/GitHub-Actions-with-sbt.html) uses [actions/setup-java](https://github.com/actions/setup-java) instead of [olafurpg/setup-scala:](https://github.com/olafurpg/setup-scala) since 9 hours ago.